### PR TITLE
Add sequential brave/gemini research agent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+.venv/
+*.log

--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-Fill
+# Multi Agent Research
+
+This project provides a sequential multi-agent web research system that uses
+Brave Search to gather information and Gemini to summarize the results.
+
+## Setup
+
+Use [`uv`](https://github.com/astral-sh/uv) for isolated Python environments and
+dependency management:
+
+```bash
+uv venv .venv
+source .venv/bin/activate
+uv pip install -e .[dev]
+```
+
+Set the following environment variables with your API keys:
+
+- `BRAVE_SEARCH_API_KEY`
+- `GEMINI_API_KEY`
+
+## Usage
+
+Run the example script:
+
+```bash
+python examples/run_research.py
+```
+
+## Testing
+
+```bash
+pytest
+```

--- a/examples/run_research.py
+++ b/examples/run_research.py
@@ -1,0 +1,15 @@
+"""Example script for running the research agent."""
+from multi_agent_research import BraveSearchClient, GeminiClient, ResearchAgent
+
+
+def main() -> None:
+    brave = BraveSearchClient()
+    gemini = GeminiClient()
+    agent = ResearchAgent(brave, gemini)
+    query = "open source multi agent systems"
+    summary = agent.run(query)
+    print(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "multi_agent_research"
+version = "0.1.0"
+description = "Sequential multi-agent web research system with Brave search and Gemini summarization."
+authors = [{name = "Example Author", email = "author@example.com"}]
+requires-python = ">=3.8"
+dependencies = [
+    "requests",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+    "responses",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/src/multi_agent_research/__init__.py
+++ b/src/multi_agent_research/__init__.py
@@ -1,0 +1,7 @@
+"""Multi-agent web research system."""
+
+from .agent import ResearchAgent
+from .brave import BraveSearchClient
+from .gemini import GeminiClient
+
+__all__ = ["ResearchAgent", "BraveSearchClient", "GeminiClient"]

--- a/src/multi_agent_research/agent.py
+++ b/src/multi_agent_research/agent.py
@@ -1,0 +1,23 @@
+"""Research agent that uses Brave search and Gemini."""
+from __future__ import annotations
+
+from typing import List
+
+from .brave import BraveSearchClient
+from .gemini import GeminiClient
+
+
+class ResearchAgent:
+    """Simple sequential research agent."""
+
+    def __init__(self, brave: BraveSearchClient, gemini: GeminiClient):
+        self.brave = brave
+        self.gemini = gemini
+
+    def run(self, query: str) -> str:
+        """Search the web and summarize results."""
+        results = self.brave.search(query)
+        snippets = "\n".join(r.get("description", "") for r in results)
+        prompt = f"Summarize the following search results for the query '{query}':\n{snippets}"
+        summary = self.gemini.generate_content(prompt)
+        return summary

--- a/src/multi_agent_research/brave.py
+++ b/src/multi_agent_research/brave.py
@@ -1,0 +1,27 @@
+"""Brave search client."""
+from __future__ import annotations
+
+import os
+from typing import List
+import requests
+
+
+class BraveSearchClient:
+    """Simple wrapper around Brave search API."""
+
+    BASE_URL = "https://api.search.brave.com/res/v1/web/search"
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.getenv("BRAVE_SEARCH_API_KEY")
+        if not self.api_key:
+            raise ValueError("BRAVE_SEARCH_API_KEY not provided")
+
+    def search(self, query: str, count: int = 5) -> List[dict]:
+        """Return a list of search result objects."""
+        params = {"q": query, "count": count}
+        headers = {"Accept": "application/json", "X-Subscription-Token": self.api_key}
+        resp = requests.get(self.BASE_URL, params=params, headers=headers, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        results = data.get("web", {}).get("results", [])
+        return results

--- a/src/multi_agent_research/gemini.py
+++ b/src/multi_agent_research/gemini.py
@@ -1,0 +1,26 @@
+"""Gemini API client."""
+from __future__ import annotations
+
+import os
+import requests
+
+
+class GeminiClient:
+    """Wrapper around Gemini text generation API."""
+
+    BASE_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:generateContent"
+
+    def __init__(self, api_key: str | None = None):
+        self.api_key = api_key or os.getenv("GEMINI_API_KEY")
+        if not self.api_key:
+            raise ValueError("GEMINI_API_KEY not provided")
+
+    def generate_content(self, prompt: str) -> str:
+        """Generate content from Gemini API."""
+        params = {"key": self.api_key}
+        headers = {"Content-Type": "application/json"}
+        body = {"contents": [{"parts": [{"text": prompt}]}]}
+        resp = requests.post(self.BASE_URL, params=params, json=body, headers=headers, timeout=30)
+        resp.raise_for_status()
+        data = resp.json()
+        return data["candidates"][0]["content"]["parts"][0]["text"]

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -1,0 +1,34 @@
+import sys, pathlib; sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+from multi_agent_research.agent import ResearchAgent
+
+
+class DummyBrave:
+    def __init__(self):
+        self.queries = []
+
+    def search(self, query: str):
+        self.queries.append(query)
+        return [
+            {"description": "result 1"},
+            {"description": "result 2"},
+        ]
+
+
+class DummyGemini:
+    def __init__(self):
+        self.prompts = []
+
+    def generate_content(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        return "summary"
+
+
+def test_research_agent_sequence():
+    brave = DummyBrave()
+    gemini = DummyGemini()
+    agent = ResearchAgent(brave, gemini)
+    result = agent.run("test query")
+    assert result == "summary"
+    assert brave.queries == ["test query"]
+    assert len(gemini.prompts) == 1
+    assert "test query" in gemini.prompts[0]


### PR DESCRIPTION
## Summary
- implement sequential research agent package
- add brave search and gemini clients
- provide example script and tests
- document usage with uv

## Testing
- `uv pip install -e .[dev] --system`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742ce7b7548321ac81d29a976720b2