### PR TITLE
Refactor to lead-agent with subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Multi Agent Research
 
-This project provides a sequential multi-agent web research system that uses
-Brave Search to gather information and Gemini to summarize the results.
+This project provides a simple multi-agent web research system. A lead Gemini
+agent decomposes the user query into subqueries, spawns Brave-powered search
+subagents, and then summarizes their findings.
 
 ## Setup
 

--- a/examples/run_research.py
+++ b/examples/run_research.py
@@ -5,7 +5,7 @@ from multi_agent_research import BraveSearchClient, GeminiClient, ResearchAgent
 def main() -> None:
     brave = BraveSearchClient()
     gemini = GeminiClient()
-    agent = ResearchAgent(brave, gemini)
+    agent = ResearchAgent(brave, gemini, num_subagents=2)
     query = "open source multi agent systems"
     summary = agent.run(query)
     print(summary)

--- a/src/multi_agent_research/__init__.py
+++ b/src/multi_agent_research/__init__.py
@@ -1,7 +1,12 @@
 """Multi-agent web research system."""
 
-from .agent import ResearchAgent
+from .agent import ResearchAgent, SearchSubAgent
 from .brave import BraveSearchClient
 from .gemini import GeminiClient
 
-__all__ = ["ResearchAgent", "BraveSearchClient", "GeminiClient"]
+__all__ = [
+    "ResearchAgent",
+    "SearchSubAgent",
+    "BraveSearchClient",
+    "GeminiClient",
+]

--- a/src/multi_agent_research/agent.py
+++ b/src/multi_agent_research/agent.py
@@ -1,4 +1,4 @@
-"""Research agent that uses Brave search and Gemini."""
+"""Research agent using a lead Gemini agent with search subagents."""
 from __future__ import annotations
 
 from typing import List
@@ -7,17 +7,53 @@ from .brave import BraveSearchClient
 from .gemini import GeminiClient
 
 
-class ResearchAgent:
-    """Simple sequential research agent."""
+class SearchSubAgent:
+    """Subagent that performs a web search using Brave."""
 
-    def __init__(self, brave: BraveSearchClient, gemini: GeminiClient):
+    def __init__(self, brave: BraveSearchClient):
+        self.brave = brave
+
+    def run(self, query: str) -> list[dict]:
+        """Execute the search and return the raw results."""
+        return self.brave.search(query)
+
+
+class ResearchAgent:
+    """Lead agent that coordinates search subagents."""
+
+    def __init__(self, brave: BraveSearchClient, gemini: GeminiClient, *, num_subagents: int = 3):
         self.brave = brave
         self.gemini = gemini
+        self.num_subagents = num_subagents
+
+    # Planning -----------------------------------------------------------------
+    def _plan_subqueries(self, query: str) -> List[str]:
+        """Use Gemini to break the query into subqueries."""
+        prompt = (
+            "Break the following research question into "
+            f"{self.num_subagents} independent search tasks. "
+            "Return them as a numbered list.\n" + query
+        )
+        plan = self.gemini.generate_content(prompt)
+        subqueries = []
+        for line in plan.splitlines():
+            if "." in line:
+                part = line.split(".", 1)[1].strip()
+                if part:
+                    subqueries.append(part)
+        return subqueries[: self.num_subagents] or [query]
+
+    # Execution ----------------------------------------------------------------
+    def _run_subagent(self, subquery: str) -> str:
+        agent = SearchSubAgent(self.brave)
+        results = agent.run(subquery)
+        snippets = "\n".join(r.get("description", "") for r in results)
+        return f"Results for '{subquery}':\n{snippets}"
 
     def run(self, query: str) -> str:
-        """Search the web and summarize results."""
-        results = self.brave.search(query)
-        snippets = "\n".join(r.get("description", "") for r in results)
-        prompt = f"Summarize the following search results for the query '{query}':\n{snippets}"
-        summary = self.gemini.generate_content(prompt)
-        return summary
+        """Plan, delegate to subagents, and summarize results."""
+        subqueries = self._plan_subqueries(query)
+        findings = [self._run_subagent(q) for q in subqueries]
+        context = "\n\n".join(findings)
+        prompt = f"Summarize the following research findings for '{query}':\n{context}"
+        return self.gemini.generate_content(prompt)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -20,15 +20,18 @@ class DummyGemini:
 
     def generate_content(self, prompt: str) -> str:
         self.prompts.append(prompt)
+        if "independent search tasks" in prompt:
+            return "1. topic one\n2. topic two"
         return "summary"
 
 
 def test_research_agent_sequence():
     brave = DummyBrave()
     gemini = DummyGemini()
-    agent = ResearchAgent(brave, gemini)
+    agent = ResearchAgent(brave, gemini, num_subagents=2)
     result = agent.run("test query")
     assert result == "summary"
-    assert brave.queries == ["test query"]
-    assert len(gemini.prompts) == 1
+    assert brave.queries == ["topic one", "topic two"]
+    # first prompt for planning, second for summarization
+    assert len(gemini.prompts) == 2
     assert "test query" in gemini.prompts[0]


### PR DESCRIPTION
## Summary
- implement lead Gemini agent that plans subqueries and spawns Brave search subagents
- expose new SearchSubAgent in package
- update example to use multiple subagents
- adjust unit test for new workflow
- update README to describe multi-agent process

## Testing
- `pip install requests --quiet`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68742f842f008321a24f141199649422