### PR TITLE
Add .env support and sequential workflow update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .venv/
 *.log
+.env

--- a/README.md
+++ b/README.md
@@ -15,10 +15,12 @@ source .venv/bin/activate
 uv pip install -e .[dev]
 ```
 
-Set the following environment variables with your API keys:
+Create a `.env` file and set your API keys:
 
-- `BRAVE_SEARCH_API_KEY`
-- `GEMINI_API_KEY`
+```bash
+BRAVE_SEARCH_API_KEY=your_brave_key
+GEMINI_API_KEY=your_gemini_key
+```
 
 ## Usage
 

--- a/src/multi_agent_research/agent.py
+++ b/src/multi_agent_research/agent.py
@@ -45,10 +45,22 @@ class ResearchAgent:
 
     # Execution ----------------------------------------------------------------
     def _run_subagent(self, subquery: str) -> str:
+        """Run a single search subagent and summarize the findings."""
         agent = SearchSubAgent(self.brave)
         results = agent.run(subquery)
-        snippets = "\n".join(r.get("description", "") for r in results)
-        return f"Results for '{subquery}':\n{snippets}"
+        items = []
+        for r in results:
+            title = r.get("title", "")
+            url = r.get("url", "")
+            desc = r.get("description", "")
+            items.append(f"- {title} ({url}): {desc}")
+        search_context = "\n".join(items)
+        prompt = (
+            f"Summarize the following search results for '{subquery}' "
+            "in 2-3 sentences and mention any useful URLs.\n" + search_context
+        )
+        summary = self.gemini.generate_content(prompt)
+        return summary
 
     def run(self, query: str) -> str:
         """Plan, delegate to subagents, and summarize results."""

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -32,6 +32,6 @@ def test_research_agent_sequence():
     result = agent.run("test query")
     assert result == "summary"
     assert brave.queries == ["topic one", "topic two"]
-    # first prompt for planning, second for summarization
-    assert len(gemini.prompts) == 2
+    # planning + subagent summaries + final summary
+    assert len(gemini.prompts) == 4
     assert "test query" in gemini.prompts[0]


### PR DESCRIPTION
## Summary
- support `.env` file with `BRAVE_SEARCH_API_KEY` and `GEMINI_API_KEY`
- improve sequential research workflow to summarize search results
- update tests for new summarization step

## Testing
- `pip install -e .[dev]`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687430f543b4832197b605a243596f0b